### PR TITLE
重构移速倍率 Hook、增加上限保护并加固导航安全

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Folder.DotSettings.user
 packages.lock.json
 *.DotSettings.user
+.slim/deepwork/

--- a/SkyEye/ConfigWindow.Chest.cs
+++ b/SkyEye/ConfigWindow.Chest.cs
@@ -7,7 +7,7 @@ namespace SkyEye;
 public partial class ConfigWindow {
 	private static void DrawChest() {
 		if (ImGui.Checkbox("宝箱位置绘制开关", ref Configuration.Overlay3DEnabled)) Configuration.Save();
-		if (ImGui.Checkbox("进入新场景禁用开宝箱", ref Configuration.DisableAutoRabbitWhenTerritoryChanged)) Configuration.Save();
+		if (ImGui.Checkbox("进入ULK自动关闭兔子自动开箱/导航", ref Configuration.DisableAutoRabbitWhenTerritoryChanged)) Configuration.Save();
 		if (ImGui.Checkbox("自动开宝箱", ref Configuration.AutoRabbit)) Configuration.Save();
 		if (Configuration.AutoRabbit) {
 			ImGui.Indent();

--- a/SkyEye/ConfigWindow.OccultPot.cs
+++ b/SkyEye/ConfigWindow.OccultPot.cs
@@ -5,7 +5,8 @@ namespace SkyEye;
 
 public partial class ConfigWindow {
 	private void DrawOccultPot() {
-		if (ImGui.Checkbox("进入新场景禁用开宝箱", ref Configuration.DisableAutoPotWhenTerritoryChanged)) Configuration.Save();
+		if (ImGui.Checkbox("进入月岛自动关闭罐子自动开箱", ref Configuration.DisableAutoPotWhenTerritoryChanged)) Configuration.Save();
+		if (ImGui.Checkbox("启用月岛罐子导航/传送", ref Configuration.EnableOccultPotNavigation)) Configuration.Save();
 		if (ImGui.Checkbox("自动开宝箱", ref Configuration.AutoPot)) Configuration.Save();
 		if (Configuration.AutoPot) {
 			ImGui.Indent();
@@ -13,10 +14,14 @@ public partial class ConfigWindow {
 			if (ImGui.InputText("开宝箱后指令(|分割)", ref Configuration.AfterFindPot)) Configuration.Save();
 			ImGui.Unindent();
 		}
-		if (ImGui.Button("立刻寻找")) FindPot(true);
-		ImGui.Indent();
-		if (ImGui.InputText("开始导航到罐子前指令(|分割)", ref Configuration.BeforeGotoNewPot)) Configuration.Save();
-		ImGui.Unindent();
+		if (Configuration.EnableOccultPotNavigation) {
+			if (ImGui.Button("立刻寻找")) FindPot(true);
+			ImGui.Indent();
+			if (ImGui.InputText("开始导航到罐子前指令(|分割)", ref Configuration.BeforeGotoNewPot)) Configuration.Save();
+			ImGui.Unindent();
+		} else {
+			ImGui.Text("默认关闭，避免进图后误导航/传送到罐子。");
+		}
 
 		ImGui.Separator();
 		ImGui.Text("统计");

--- a/SkyEye/ConfigWindow.Speed.cs
+++ b/SkyEye/ConfigWindow.Speed.cs
@@ -1,92 +1,115 @@
-﻿using System;
 using System.Linq;
 using System.Text;
 using Dalamud.Bindings.ImGui;
-using Dalamud.Utility;
 using static SkyEye.Plugin;
 using static SkyEye.MConfiguration;
 using static SkyEye.Util;
 
-
 namespace SkyEye;
 
 public partial class ConfigWindow {
-	private static void ValidateSpeedInfo() {
-		SetSpeed(1);
-		if (!Configuration.SpeedUp[0].SpeedUpTerritory.Equals(SpeedInfo.Default().SpeedUpTerritory))
-			Configuration.SpeedUp[0].SpeedUpTerritory = SpeedInfo.Default().SpeedUpTerritory;
-		if (!Configuration.SpeedUp[0].Desc.Equals(SpeedInfo.Default().Desc))
-			Configuration.SpeedUp[0].Desc = SpeedInfo.Default().Desc;
-		if (!Configuration.SpeedUp[0].SpeedUpMountX.Equals(SpeedInfo.Default().SpeedUpMountX))
-			Configuration.SpeedUp[0].SpeedUpMountX = SpeedInfo.Default().SpeedUpMountX;
-		if (Configuration.SpeedUp[^2].SpeedUpTerritory.IsNullOrEmpty())
-			Configuration.SpeedUp.Remove(Configuration.SpeedUp[^2]);
-		if (!Configuration.SpeedUp[^1].SpeedUpTerritory.IsNullOrEmpty())
-			Configuration.SpeedUp.Add(new SpeedInfo());
-		CurrentSpeedInfo = null;
-		foreach (var s in Configuration.SpeedUp.Where(s => s.Enabled && s.SpeedUpTerritory.Split('|').Contains(ClientState.TerritoryType.ToString()))) {
-			CurrentSpeedInfo = s;
-			break;
-		}
-		SetSpeed(1);
+	private static void SpeedConfigurationChanged() {
+		RefreshCurrentSpeedInfo();
 		Configuration.Save();
+	}
+
+	private static bool InputPositiveSpeed(string label, ref float value) {
+		var previous = value;
+		if (!ImGui.InputFloat(label, ref value)) return false;
+		if (!IsValidSpeedValue(value)) {
+			value = previous;
+			return false;
+		}
+		return true;
 	}
 
 	private static void DrawSpeed() {
 		ImGui.Text("提示：");
-		ImGui.Text("走路倍率6，坐骑倍率6*2。死亡会掉速，点击重置即可恢复。");
+		ImGui.Text("最终移速按配置的基础移速×倍率计算，并受速度上限限制。死亡会掉速，点击重置即可恢复。");
 		ImGui.Text("地区id用竖线|隔开。");
-		if (ImGui.Checkbox("无人就加速", ref Configuration.SpeedUpEnabled)) Configuration.Save();
+		if (ImGui.Checkbox("无人就加速", ref Configuration.SpeedUpEnabled)) {
+			if (!Configuration.SpeedUpEnabled) RestoreSpeed(true);
+			else RefreshCurrentSpeedInfo(resetFailures: true);
+			Configuration.Save();
+		}
+		ImGui.SameLine();
+		if (ImGui.Checkbox("输出基础移速调试信息", ref Configuration.SpeedDebugOutput)) Configuration.Save();
 		ImGui.SameLine();
 		if (ImGui.Button("重置")) {
-			foreach (var s in Configuration.SpeedUp.Where(s => s.Enabled && s.SpeedUpTerritory.Split('|').Contains(ClientState.TerritoryType.ToString()))) {
-				CurrentSpeedInfo = s;
-				break;
-			}
-			SetSpeed(1);
+			RefreshCurrentSpeedInfo(resetFailures: true);
 		}
-		ImGui.Text("从下往上删没问题，从中间删会导致null项目，点击即可清除");
-		ImGui.SameLine();
-		if (ImGui.Button("清空null项目")) {
-			Configuration.SpeedUp = Configuration.SpeedUp.Where(i => !i.SpeedUpTerritory.IsNullOrEmpty()).ToList();
-			ValidateSpeedInfo();
+		if (ImGui.Button("添加配置")) {
+			RestoreSpeed(true);
+			Configuration.SpeedUp.Add(new SpeedInfo());
+			SpeedConfigurationChanged();
 		}
+
 		if (Configuration.SpeedUpEnabled) {
-			string[] header = ["启用", "地区Id", "倍率", "最终速度上限(含乘算倍率)", "基础坐骑速度倍率(默认2)", "备注"];
+			string[] header = ["启用", "地区Id", "基础移速", "坐骑基础移速", "倍率", "最终速度上限", "备注", "操作"];
+			var deleteIndex = -1;
 			if (ImGui.BeginTable("TableSpeedInfo", header.Length, ImGuiTableFlag)) {
 				foreach (var item in header) ImGui.TableSetupColumn(item, ImGuiTableColumnFlags.WidthStretch);
 				ImGui.TableHeadersRow();
 				for (var i = 0; i < Configuration.SpeedUp.Count; i++) {
+					var speedInfo = Configuration.SpeedUp[i];
 					ImGui.TableNextRow();
+					if (speedInfo == null) {
+						ImGui.TableSetColumnIndex(1);
+						ImGui.Text("无效的 null 配置项");
+						ImGui.TableSetColumnIndex(7);
+						if (ImGui.Button($"删除##速度null{i}")) deleteIndex = i;
+						continue;
+					}
+					var isDefault = speedInfo.IsDefault;
+					var territoryText = speedInfo.SpeedUpTerritory ?? string.Empty;
+					var descText = speedInfo.Desc ?? string.Empty;
 					ImGui.TableSetColumnIndex(0);
-					if (ImGui.Checkbox($"##启用{i}", ref Configuration.SpeedUp[i].Enabled)) ValidateSpeedInfo();
+					if (ImGui.Checkbox($"##启用{i}", ref speedInfo.Enabled)) SpeedConfigurationChanged();
 					ImGui.TableSetColumnIndex(1);
 					ImGui.SetNextItemWidth(-1);
-					if (ImGui.InputText($"##地区{i}", ref Configuration.SpeedUp[i].SpeedUpTerritory)) ValidateSpeedInfo();
+					if (isDefault) ImGui.Text(territoryText);
+					else if (ImGui.InputText($"##地区{i}", ref territoryText)) {
+						speedInfo.SpeedUpTerritory = territoryText;
+						SpeedConfigurationChanged();
+					}
 					if (ImGui.IsItemHovered()) {
 						var sb = new StringBuilder();
-						foreach (var t in Configuration.SpeedUp[i].SpeedUpTerritory.Split('|'))
-							if (!t.IsNullOrEmpty() && MapInfo.TryGetValue(t, out var value))
-								sb.Append(t).Append('|').Append(value).Append('\n');
-						if (sb.Length != 0) {
-							sb.Remove(sb.Length - 1, 1);
-							ImGui.SetTooltip(sb.ToString());
-						}
+						foreach (var territory in territoryText.Split('|'))
+							if (!string.IsNullOrEmpty(territory) && MapInfo.TryGetValue(territory, out var value))
+								sb.Append(territory).Append('|').Append(value).Append('\n');
+						if (sb.Length != 0) ImGui.SetTooltip(sb.ToString().TrimEnd());
 					}
 					ImGui.TableSetColumnIndex(2);
 					ImGui.SetNextItemWidth(-1);
-					if (ImGui.InputFloat($"##倍率{i}", ref Configuration.SpeedUp[i].SpeedUpN)) ValidateSpeedInfo();
+					if (isDefault) ImGui.Text(speedInfo.BaseMovementSpeed.ToString());
+					else if (InputPositiveSpeed($"##基础移速{i}", ref speedInfo.BaseMovementSpeed)) SpeedConfigurationChanged();
 					ImGui.TableSetColumnIndex(3);
 					ImGui.SetNextItemWidth(-1);
-					if (ImGui.InputFloat($"##最大{i}", ref Configuration.SpeedUp[i].SpeedUpMax)) ValidateSpeedInfo();
+					if (isDefault) ImGui.Text(speedInfo.MountBaseMovementSpeed.ToString());
+					else if (InputPositiveSpeed($"##坐骑基础移速{i}", ref speedInfo.MountBaseMovementSpeed)) SpeedConfigurationChanged();
 					ImGui.TableSetColumnIndex(4);
 					ImGui.SetNextItemWidth(-1);
-					if (ImGui.InputFloat($"##基础坐骑倍率{i}", ref Configuration.SpeedUp[i].SpeedUpMountX)) ValidateSpeedInfo();
+					if (InputPositiveSpeed($"##倍率{i}", ref speedInfo.SpeedUpN)) SpeedConfigurationChanged();
 					ImGui.TableSetColumnIndex(5);
 					ImGui.SetNextItemWidth(-1);
-					if (ImGui.InputText($"##描述{i}", ref Configuration.SpeedUp[i].Desc)) ValidateSpeedInfo();
+					if (InputPositiveSpeed($"##最大{i}", ref speedInfo.SpeedUpMax)) SpeedConfigurationChanged();
+					ImGui.TableSetColumnIndex(6);
+					ImGui.SetNextItemWidth(-1);
+					if (isDefault) ImGui.Text(descText);
+					else if (ImGui.InputText($"##描述{i}", ref descText)) {
+						speedInfo.Desc = descText;
+						SpeedConfigurationChanged();
+					}
+					ImGui.TableSetColumnIndex(7);
+					if (isDefault) ImGui.Text("默认配置");
+					else if (ImGui.Button($"删除##速度{i}")) deleteIndex = i;
 				}
 				ImGui.EndTable();
+			}
+			if (deleteIndex >= 0) {
+				RestoreSpeed(true);
+				Configuration.SpeedUp.RemoveAt(deleteIndex);
+				SpeedConfigurationChanged();
 			}
 		}
 		ImGui.Text("无视周边的挂壁亲友（用竖线|隔开）");

--- a/SkyEye/ConfigWindow.Speed.cs
+++ b/SkyEye/ConfigWindow.Speed.cs
@@ -25,27 +25,29 @@ public partial class ConfigWindow {
 
 	private static void DrawSpeed() {
 		ImGui.Text("提示：");
-		ImGui.Text("最终移速按配置的基础移速×倍率计算，并受速度上限限制。死亡会掉速，点击重置即可恢复。");
+		ImGui.Text("移速算法已重置，目前是hook游戏基础移速×配置倍率。");
+		ImGui.Text("特殊场景上限基本都是3.5左右，高了基本掉线，视网络情况而定");
+		ImGui.Text("保护公式：最终倍率=min(游戏原始倍率×配置倍率, 每行上限)，技能加速也会被截断。");
 		ImGui.Text("地区id用竖线|隔开。");
 		if (ImGui.Checkbox("无人就加速", ref Configuration.SpeedUpEnabled)) {
-			if (!Configuration.SpeedUpEnabled) RestoreSpeed(true);
+			if (!Configuration.SpeedUpEnabled) RestoreSpeed();
 			else RefreshCurrentSpeedInfo(resetFailures: true);
 			Configuration.Save();
 		}
 		ImGui.SameLine();
-		if (ImGui.Checkbox("输出基础移速调试信息", ref Configuration.SpeedDebugOutput)) Configuration.Save();
+		if (ImGui.Checkbox("输出移速倍率调试信息", ref Configuration.SpeedDebugOutput)) Configuration.Save();
 		ImGui.SameLine();
-		if (ImGui.Button("重置")) {
+		if (ImGui.Button("重新应用")) {
 			RefreshCurrentSpeedInfo(resetFailures: true);
 		}
 		if (ImGui.Button("添加配置")) {
-			RestoreSpeed(true);
+			RestoreSpeed();
 			Configuration.SpeedUp.Add(new SpeedInfo());
 			SpeedConfigurationChanged();
 		}
 
 		if (Configuration.SpeedUpEnabled) {
-			string[] header = ["启用", "地区Id", "基础移速", "坐骑基础移速", "倍率", "最终速度上限", "备注", "操作"];
+			string[] header = ["启用", "地区Id", "倍率", "最终倍率上限", "备注", "操作"];
 			var deleteIndex = -1;
 			if (ImGui.BeginTable("TableSpeedInfo", header.Length, ImGuiTableFlag)) {
 				foreach (var item in header) ImGui.TableSetupColumn(item, ImGuiTableColumnFlags.WidthStretch);
@@ -56,7 +58,7 @@ public partial class ConfigWindow {
 					if (speedInfo == null) {
 						ImGui.TableSetColumnIndex(1);
 						ImGui.Text("无效的 null 配置项");
-						ImGui.TableSetColumnIndex(7);
+						ImGui.TableSetColumnIndex(5);
 						if (ImGui.Button($"删除##速度null{i}")) deleteIndex = i;
 						continue;
 					}
@@ -81,33 +83,25 @@ public partial class ConfigWindow {
 					}
 					ImGui.TableSetColumnIndex(2);
 					ImGui.SetNextItemWidth(-1);
-					if (isDefault) ImGui.Text(speedInfo.BaseMovementSpeed.ToString());
-					else if (InputPositiveSpeed($"##基础移速{i}", ref speedInfo.BaseMovementSpeed)) SpeedConfigurationChanged();
+					if (InputPositiveSpeed($"##倍率{i}", ref speedInfo.SpeedUpN)) SpeedConfigurationChanged();
 					ImGui.TableSetColumnIndex(3);
 					ImGui.SetNextItemWidth(-1);
-					if (isDefault) ImGui.Text(speedInfo.MountBaseMovementSpeed.ToString());
-					else if (InputPositiveSpeed($"##坐骑基础移速{i}", ref speedInfo.MountBaseMovementSpeed)) SpeedConfigurationChanged();
+					if (InputPositiveSpeed($"##倍率上限{i}", ref speedInfo.SpeedMultiplierMax)) SpeedConfigurationChanged();
 					ImGui.TableSetColumnIndex(4);
-					ImGui.SetNextItemWidth(-1);
-					if (InputPositiveSpeed($"##倍率{i}", ref speedInfo.SpeedUpN)) SpeedConfigurationChanged();
-					ImGui.TableSetColumnIndex(5);
-					ImGui.SetNextItemWidth(-1);
-					if (InputPositiveSpeed($"##最大{i}", ref speedInfo.SpeedUpMax)) SpeedConfigurationChanged();
-					ImGui.TableSetColumnIndex(6);
 					ImGui.SetNextItemWidth(-1);
 					if (isDefault) ImGui.Text(descText);
 					else if (ImGui.InputText($"##描述{i}", ref descText)) {
 						speedInfo.Desc = descText;
 						SpeedConfigurationChanged();
 					}
-					ImGui.TableSetColumnIndex(7);
+					ImGui.TableSetColumnIndex(5);
 					if (isDefault) ImGui.Text("默认配置");
 					else if (ImGui.Button($"删除##速度{i}")) deleteIndex = i;
 				}
 				ImGui.EndTable();
 			}
 			if (deleteIndex >= 0) {
-				RestoreSpeed(true);
+				RestoreSpeed();
 				Configuration.SpeedUp.RemoveAt(deleteIndex);
 				SpeedConfigurationChanged();
 			}

--- a/SkyEye/ConfigWindow.Tp.cs
+++ b/SkyEye/ConfigWindow.Tp.cs
@@ -18,12 +18,14 @@ public partial class ConfigWindow {
 
 
 	private static void DrawTp() {
-		if (!HasCore()) {
-			ImGui.Text("自定义Tp为其他插件的潜水tp指令。");
-			ImGui.Text("自定义Tp指令的坐标使用<x> <y> <z>(有尖括号)代替(例如/tp <x> <y> <z>)");
-			if (ImGui.InputText("自定义Tp指令", ref Configuration.TpCommand)) Configuration.Save();
+		ImGui.Text("自定义Tp为其他插件的潜水tp指令。");
+		ImGui.Text("自定义Tp指令的坐标使用<x> <y> <z>(有尖括号)代替(例如/tp <x> <y> <z>)");
+		if (ImGui.InputText("自定义Tp指令", ref Configuration.TpCommand)) Configuration.Save();
+		if (HasCore()) ImGui.Text("当前已检测到 LatihasDalamudCore，将优先使用 Core 的潜水功能。");
+		if (!CanTp()) {
+			ImGui.Text("未检测到可用的潜水 TP 功能，请填写自定义 TP 指令");
+			return;
 		}
-		if (!CanTp()) return;
 		if (ImGui.Checkbox("绿玩在附近也tp", ref Configuration.CoreTpWhenGreenNearby)) Configuration.Save();
 		if (ObjectTable.LocalPlayer == null) return;
 		if (ImGui.Button("潜水无敌")) CoreDive(true);

--- a/SkyEye/ConfigWindow.cs
+++ b/SkyEye/ConfigWindow.cs
@@ -11,9 +11,13 @@ namespace SkyEye;
 
 public partial class ConfigWindow() : Window("SkyEye") {
 	public override void Draw() {
-		if (ImGui.Checkbox("开关", ref Configuration.PluginEnabled)) Configuration.Save();
+		if (ImGui.Checkbox("开关", ref Configuration.PluginEnabled)) {
+			if (!Configuration.PluginEnabled) RestoreSpeed(true);
+			else RefreshCurrentSpeedInfo(resetFailures: true);
+			Configuration.Save();
+		}
 		if (!Configuration.PluginEnabled) {
-			SetSpeed(1);
+			RestoreSpeed();
 			lastFarmPos = null;
 			FarmFull = false;
 			Stop();
@@ -32,6 +36,11 @@ public partial class ConfigWindow() : Window("SkyEye") {
 			NewTab("月岛", () => {
 				if (ImGui.BeginTabBar("月岛tab")) {
 					NewTab("萝卜", () => {
+						if (ImGui.Checkbox("启用月岛萝卜导航/传送", ref Configuration.EnableOccultBunnyNavigation)) Configuration.Save();
+						if (!Configuration.EnableOccultBunnyNavigation) {
+							ImGui.Text("默认关闭，避免进图后误传送到萝卜点位。");
+							return;
+						}
 						foreach (var p in PData.OccultBunnyPosition
 							         .Where(p => ClientState.TerritoryType == p.Key))
 							for (var i = 0; i < p.Value.Count; i++) {

--- a/SkyEye/MConfiguration.cs
+++ b/SkyEye/MConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Dalamud.Configuration;
 using static SkyEye.Plugin;
@@ -11,14 +12,14 @@ public class MConfiguration : IPluginConfiguration {
 	public float FarmMaxDistance = 100, FarmWaitX, FarmWaitY, FarmWaitZ, FlagR = 100;
 	public int FarmTargetMax = 1, WssRegion, FarmDistAlgo, NextWeatherCount = 10,
 		OccultTreasureDelay = 2000;
-	public bool PluginEnabled = true, SpeedUpEnabled = true, Overlay2DWeatherMapEnabled = true, Overlay2DDetailEnabled = true, Overlay3DEnabled = true,
+	public bool PluginEnabled = true, SpeedUpEnabled = true, SpeedDebugOutput, Overlay2DWeatherMapEnabled = true, Overlay2DDetailEnabled = true, Overlay3DEnabled = true,
 		AutoRabbit = true, AutoForwardNewRabbit = true,
-		AutoPot, Auto30OccultTreasure,
+		AutoPot, Auto30OccultTreasure, EnableOccultBunnyNavigation, EnableOccultPotNavigation,
 		AutoFarm, FarmWait,
 		EnableWss,
 		ShowCurrentElemental,
-		DisableAutoRabbitWhenTerritoryChanged,
-		DisableAutoPotWhenTerritoryChanged,
+		DisableAutoRabbitWhenTerritoryChanged = true,
+		DisableAutoPotWhenTerritoryChanged = true,
 		PreventTp, NameReplacement, EnablePalacePal,
 		FindCharaNiao, FindCharaMao, FindCharaGou, FindCharaZhu,
 		FindRaceRenM, FindRaceRenF,
@@ -46,18 +47,40 @@ public class MConfiguration : IPluginConfiguration {
 
 	public record SpeedInfo {
 		public string Desc = "";
-		public bool Enabled;
+		public bool Enabled, IsDefault;
+		// Configurable on-foot/mounted base movement speeds, multiplier and final cap.
+		public float BaseMovementSpeed = 6f;
+		public float MountBaseMovementSpeed = 9.6f;
 		public float SpeedUpMax = 20f;
-		public float SpeedUpMountX = 2f;
 		public float SpeedUpN = 3.5f;
+		// Legacy mount multiplier retained only for old configuration deserialization.
+		public float SpeedUpMountX = 2f;
 		public string SpeedUpTerritory = "";
 		private static readonly SpeedInfo _default = new() {
 			Desc = "ULK, 该行地区Id与描述不可修改",
 			SpeedUpTerritory = "732|763|795|827",
-			SpeedUpMountX = 1.6f,
-			Enabled = true
+			BaseMovementSpeed = 6f,
+			MountBaseMovementSpeed = 9.6f,
+			Enabled = true,
+			IsDefault = true
 		};
 
-		public static SpeedInfo Default() => _default;
+		public static SpeedInfo Default() => new() {
+			Desc = _default.Desc,
+			SpeedUpTerritory = _default.SpeedUpTerritory,
+			BaseMovementSpeed = _default.BaseMovementSpeed,
+			MountBaseMovementSpeed = _default.MountBaseMovementSpeed,
+			Enabled = _default.Enabled,
+			IsDefault = true
+		};
+
+		internal static bool HasLegacyDefaultCharacteristics(SpeedInfo speedInfo) {
+			var expectedTerritories = _default.SpeedUpTerritory.Split('|', StringSplitOptions.RemoveEmptyEntries);
+			var actualTerritories = (speedInfo.SpeedUpTerritory ?? string.Empty).Split('|', StringSplitOptions.RemoveEmptyEntries);
+			return actualTerritories.Length == expectedTerritories.Length &&
+			       actualTerritories.Distinct().Count() == expectedTerritories.Length &&
+			       expectedTerritories.All(actualTerritories.Contains) &&
+			       string.Equals(speedInfo.Desc ?? string.Empty, _default.Desc, StringComparison.Ordinal);
+		}
 	}
 }

--- a/SkyEye/MConfiguration.cs
+++ b/SkyEye/MConfiguration.cs
@@ -46,21 +46,19 @@ public class MConfiguration : IPluginConfiguration {
 	public void Save() => PluginInterface.SavePluginConfig(this);
 
 	public record SpeedInfo {
+		public const float DefaultSpeedMultiplierMax = 3.5f;
 		public string Desc = "";
 		public bool Enabled, IsDefault;
-		// Configurable on-foot/mounted base movement speeds, multiplier and final cap.
+		public float SpeedUpN = 3.5f;
+		public float SpeedMultiplierMax = DefaultSpeedMultiplierMax;
 		public float BaseMovementSpeed = 6f;
 		public float MountBaseMovementSpeed = 9.6f;
 		public float SpeedUpMax = 20f;
-		public float SpeedUpN = 3.5f;
-		// Legacy mount multiplier retained only for old configuration deserialization.
 		public float SpeedUpMountX = 2f;
 		public string SpeedUpTerritory = "";
 		private static readonly SpeedInfo _default = new() {
 			Desc = "ULK, 该行地区Id与描述不可修改",
 			SpeedUpTerritory = "732|763|795|827",
-			BaseMovementSpeed = 6f,
-			MountBaseMovementSpeed = 9.6f,
 			Enabled = true,
 			IsDefault = true
 		};
@@ -68,8 +66,6 @@ public class MConfiguration : IPluginConfiguration {
 		public static SpeedInfo Default() => new() {
 			Desc = _default.Desc,
 			SpeedUpTerritory = _default.SpeedUpTerritory,
-			BaseMovementSpeed = _default.BaseMovementSpeed,
-			MountBaseMovementSpeed = _default.MountBaseMovementSpeed,
 			Enabled = _default.Enabled,
 			IsDefault = true
 		};

--- a/SkyEye/Plugin.cs
+++ b/SkyEye/Plugin.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +12,7 @@ using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.Command;
+using Dalamud.Hooking;
 using Dalamud.Interface.Windowing;
 using Dalamud.IoC;
 using Dalamud.Plugin;
@@ -40,13 +40,13 @@ namespace SkyEye;
 public sealed partial class Plugin : IDalamudPlugin {
 	private const uint LuckyCarrotItemId = 2002482;
 	private const uint LuckyPotItemId = 2003296;
-	private const int CurrentConfigurationVersion = 1;
-	private const string BaseMovementSpeedSignature = "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 84 C0 75 4F";
-	private const int BaseMovementSpeedOffset = 0x58;
+	private const int CurrentConfigurationVersion = 2;
+	private const string SpeedMultiplierCalculateSignature = "40 57 48 83 EC ?? 48 8B F9 48 8B 49 ?? 48 8B 01 FF 90 ?? ?? ?? ?? 48 85 C0 75";
 	private const float SpeedComparisonTolerance = 0.001f;
-	private const long SpeedRetryDelayMilliseconds = 1000;
+	private const long SpeedHookRetryDelayMilliseconds = 1000;
 	internal const int FarmTimeout = 50;
-	private static float _lSpeed = float.NaN;
+	private sealed record SpeedMultiplierState(float Multiplier, float MaxMultiplier);
+	private static SpeedMultiplierState _speedMultiplierState = new(1f, 0f);
 	internal static List<Vector3> DetectedTreasurePositions = [];
 	internal static readonly List<IPlayerCharacter> OtherPlayer = [];
 	internal static readonly List<Vector3> ElementalPositions = [];
@@ -58,17 +58,16 @@ public sealed partial class Plugin : IDalamudPlugin {
 	private static readonly Lock KillingLock = new();
 	internal static Vector3? lastFarmPos;
 	internal static bool FarmFull;
-	private static IntPtr? BaseMovementSpeedPtr;
-	private static IntPtr _overriddenSpeedAddress;
-	private static float _originalSpeed, _restoreWalkingBaseSpeed, _restoreMountedBaseSpeed;
-	private static long _speedRetryAfter;
-	private static bool _speedOverridden, _speedScanAttempted, _speedFailureLogged, _overrideMounted;
+	private delegate float SpeedMultiplierCalculateDelegate(nint characterSpeedContainer);
+	private static Hook<SpeedMultiplierCalculateDelegate>? _speedMultiplierCalculateHook;
+	private static SpeedMultiplierCalculateDelegate? _speedMultiplierCalculateOriginal;
+	private static long _speedHookRetryAfter;
+	private static bool _speedHookFailureLogged;
 	internal static SpeedInfo? CurrentSpeedInfo;
 	internal static Dictionary<string, string> MapInfo = new();
 	private static Timer _carrotTimer = null!, _potTimer = null!;
 	private readonly ConfigWindow _configWindow;
 	private readonly UiBuilder _uiBuilder;
-	private bool mountState;
 	// ReSharper disable once MemberCanBePrivate.Global
 	public readonly WindowSystem WindowSystem = new("SkyEye");
 
@@ -94,8 +93,6 @@ public sealed partial class Plugin : IDalamudPlugin {
 			if (Configuration.AutoPot) UsePotCarrot();
 			else StopPotTimer();
 		};
-		mountState = Condition[ConditionFlag.Mounted];
-		Framework.Update += CheckState;
 		Framework.Update += UpdateRoundPlayers;
 		Framework.Update += Farm;
 		Framework.Update += FindElemental;
@@ -113,12 +110,6 @@ public sealed partial class Plugin : IDalamudPlugin {
 			.ToDictionary(i => i.RowId.ToString(), i => $"{i.PlaceNameRegion.Value.Name}|{i.PlaceName.Value.Name}");
 		RefreshCurrentSpeedInfo(ClientState.TerritoryType);
 		if (Configuration.NameReplacement) EnableNameplate();
-	}
-
-	private void CheckState(IFramework _) {
-		if (Condition[ConditionFlag.Mounted] == mountState) return;
-		mountState = Condition[ConditionFlag.Mounted];
-		RestoreSpeed(true);
 	}
 
 	private void OnCommand() => OnCommand(null, null);
@@ -153,9 +144,8 @@ public sealed partial class Plugin : IDalamudPlugin {
 		Framework.Update -= UpdateRoundPlayers;
 		Framework.Update -= Farm;
 		Framework.Update -= FindElemental;
-		Framework.Update -= CheckState;
 		DisableNameplate();
-		RestoreSpeed(true);
+		DisposeSpeedMultiplierHook();
 		_uiBuilder.Dispose();
 		CommandManager.RemoveHandler("/skyeye");
 		_carrotTimer.Stop();
@@ -612,12 +602,17 @@ public sealed partial class Plugin : IDalamudPlugin {
 			RestoreSpeed();
 			return;
 		}
+		if (_speedMultiplierCalculateHook == null) InitializeSpeedMultiplierHook();
+		if (_speedMultiplierCalculateHook == null) {
+			RestoreSpeed();
+			return;
+		}
 		OtherPlayer.Clear();
 		foreach (var obj in ObjectTable)
 			if (obj.GameObjectId != ObjectTable.LocalPlayer.GameObjectId & obj.Address.ToInt64() != 0 && obj is IPlayerCharacter rcTemp)
 				OtherPlayer.Add(rcTemp);
 		if (GreenNearby()) RestoreSpeed();
-		else ApplyBaseMovementSpeedOverride();
+		else SetSpeedMultiplier(CurrentSpeedInfo.SpeedUpN, CurrentSpeedInfo.SpeedMultiplierMax);
 	}
 
 	internal static SpeedInfo? FindSpeedInfo(uint territoryType) {
@@ -627,10 +622,8 @@ public sealed partial class Plugin : IDalamudPlugin {
 			s.Enabled &&
 			!string.IsNullOrWhiteSpace(s.SpeedUpTerritory ?? string.Empty) &&
 			(s.SpeedUpTerritory ?? string.Empty).Split('|').Contains(territory) &&
-			IsValidSpeedValue(s.BaseMovementSpeed) &&
-			IsValidSpeedValue(s.MountBaseMovementSpeed) &&
 			IsValidSpeedValue(s.SpeedUpN) &&
-			IsValidSpeedValue(s.SpeedUpMax));
+			IsValidSpeedValue(s.SpeedMultiplierMax));
 	}
 
 	internal static bool IsValidSpeedValue(float value) => float.IsFinite(value) && value > 0f;
@@ -658,6 +651,14 @@ public sealed partial class Plugin : IDalamudPlugin {
 			Configuration.DisableAutoRabbitWhenTerritoryChanged = true;
 			Configuration.DisableAutoPotWhenTerritoryChanged = true;
 		}
+		if (Configuration.Version < 2) {
+			foreach (var speedInfo in Configuration.SpeedUp ?? []) {
+				if (speedInfo == null) continue;
+				speedInfo.SpeedMultiplierMax = IsValidSpeedValue(speedInfo.SpeedUpN)
+					? speedInfo.SpeedUpN
+					: SpeedInfo.DefaultSpeedMultiplierMax;
+			}
+		}
 		Configuration.Version = CurrentConfigurationVersion;
 		return true;
 	}
@@ -680,202 +681,103 @@ public sealed partial class Plugin : IDalamudPlugin {
 	}
 
 	internal static void RefreshCurrentSpeedInfo(uint? territoryType = null, bool resetFailures = false) {
-		if (resetFailures) ResetSpeedFailureState();
-		RestoreSpeed(true);
+		if (resetFailures) {
+			_speedHookRetryAfter = 0;
+			_speedHookFailureLogged = false;
+		}
+		RestoreSpeed();
 		CurrentSpeedInfo = FindSpeedInfo(territoryType ?? ClientState.TerritoryType);
-	}
-
-	internal static void ResetSpeedFailureState() {
-		_speedRetryAfter = 0;
-		_speedScanAttempted = false;
-		_speedFailureLogged = false;
-	}
-
-	// https://github.com/Jaksuhn/ffxiv-bundleoftweaks
-	// https://github.com/MnFeN/Triggernometry
-	[SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
-	internal static void ApplyBaseMovementSpeedOverride() {
-		var speedInfo = CurrentSpeedInfo;
-		if (SpeedRetryPending() || speedInfo == null || !Configuration.PluginEnabled || !Configuration.SpeedUpEnabled ||
-		    !IsValidSpeedValue(speedInfo.BaseMovementSpeed) || !IsValidSpeedValue(speedInfo.MountBaseMovementSpeed) ||
-		    !IsValidSpeedValue(speedInfo.SpeedUpN) || !IsValidSpeedValue(speedInfo.SpeedUpMax)) return;
-		var mounted = Condition[ConditionFlag.Mounted];
-		var baseSpeed = mounted ? speedInfo.MountBaseMovementSpeed : speedInfo.BaseMovementSpeed;
-		var requestedSpeed = Math.Min(speedInfo.SpeedUpMax, baseSpeed * speedInfo.SpeedUpN);
-		if (_speedOverridden) {
-			try {
-				var activeValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
-				if (activeValues == null || activeValues.Length == 0 || !IsValidSpeedValue(activeValues[0])) {
-					ScheduleSpeedRetry("无法校验当前基础移速覆盖值");
-					return;
-				}
-				if (float.IsFinite(_lSpeed) && SpeedApproximatelyEquals(activeValues[0], _lSpeed)) {
-					if (SpeedApproximatelyEquals(_lSpeed, requestedSpeed)) return;
-				} else {
-					Log.Information($"[BaseMovementSpeed] 检测到游戏重置基础移速为 {activeValues[0]}，重新建立覆盖状态");
-					ClearSpeedOverrideState();
-				}
-			} catch (Exception ex) {
-				ScheduleSpeedRetry("校验当前基础移速覆盖值失败", ex);
-				return;
-			}
-		}
-		if (!TryResolveBaseMovementSpeedAddress(out var address)) return;
-
-		float previousSpeed, finalSpeed;
-		try {
-			var values = SafeMemory.Read<float>(address, 1);
-			if (values == null || values.Length == 0 || !IsValidSpeedValue(values[0])) {
-				ScheduleSpeedRetry("读取当前基础移速失败");
-				if (!_speedOverridden) {
-					BaseMovementSpeedPtr = null;
-					_speedScanAttempted = false;
-				}
-				return;
-			}
-			previousSpeed = values[0];
-			finalSpeed = requestedSpeed;
-			if (!IsValidSpeedValue(finalSpeed)) {
-				ScheduleSpeedRetry("计算得到的基础移速覆盖值无效");
-				return;
-			}
-			SafeMemory.Write(address, finalSpeed);
-		} catch (Exception ex) {
-			ScheduleSpeedRetry("读写基础移速内存失败", ex);
-			if (!_speedOverridden) {
-				BaseMovementSpeedPtr = null;
-				_speedScanAttempted = false;
-			}
-			return;
-		}
-
-		if (!_speedOverridden) {
-			_originalSpeed = previousSpeed;
-			_restoreWalkingBaseSpeed = speedInfo.BaseMovementSpeed;
-			_restoreMountedBaseSpeed = speedInfo.MountBaseMovementSpeed;
-			_overrideMounted = mounted;
-			_overriddenSpeedAddress = address;
-			_speedOverridden = true;
-		}
-		_lSpeed = finalSpeed;
-		ClearSpeedRetry();
-		if (Configuration.SpeedDebugOutput) {
-			try {
-				ChatBox.SendMessage($"/e SetBaseSpeed: mounted={mounted} base={baseSpeed}*rate={speedInfo.SpeedUpN} capped={speedInfo.SpeedUpMax} {previousSpeed}->{finalSpeed}");
-			} catch (Exception ex) {
-				LogSpeedFailure("基础移速调试输出失败", ex);
-			}
-		}
+		if (_speedMultiplierCalculateHook == null) InitializeSpeedMultiplierHook();
 	}
 
 	internal static void RestoreSpeed(bool force = false) {
-		if (!_speedOverridden) {
-			_lSpeed = float.NaN;
-			return;
-		}
-		if (!force && SpeedRetryPending()) return;
-		var addressValue = _overriddenSpeedAddress.ToInt64();
-		if (_overriddenSpeedAddress == IntPtr.Zero || addressValue < 0x10000 || addressValue > 0x00007FFFFFFFFFFF) {
-			ScheduleSpeedRetry("缓存的基础移速地址不合理，暂缓恢复写入");
-			return;
-		}
-		try {
-			var currentValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
-			if (currentValues == null || currentValues.Length == 0 || !float.IsFinite(currentValues[0])) {
-				ScheduleSpeedRetry("恢复前无法确认基础移速地址可读，暂缓恢复写入");
-				return;
-			}
-			var mounted = Condition[ConditionFlag.Mounted];
-			var restoreSpeed = mounted == _overrideMounted
-				? _originalSpeed
-				: mounted ? _restoreMountedBaseSpeed : _restoreWalkingBaseSpeed;
-			if (!IsValidSpeedValue(restoreSpeed)) {
-				ScheduleSpeedRetry("没有可用的基础移速恢复值");
-				return;
-			}
-			if (SpeedApproximatelyEquals(currentValues[0], restoreSpeed)) {
-				ClearSpeedOverrideState();
-				return;
-			}
-			if (!float.IsFinite(_lSpeed) || !SpeedApproximatelyEquals(currentValues[0], _lSpeed)) {
-				Log.Warning($"[BaseMovementSpeed] 当前值已被游戏或其他插件改为 {currentValues[0]}，放弃旧覆盖状态，不写入过期恢复值");
-				ClearSpeedOverrideState();
-				return;
-			}
-			SafeMemory.Write(_overriddenSpeedAddress, restoreSpeed);
-			var restoredValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
-			if (restoredValues == null || restoredValues.Length == 0 || !float.IsFinite(restoredValues[0]) || !SpeedApproximatelyEquals(restoredValues[0], restoreSpeed)) {
-				ScheduleSpeedRetry("恢复后基础移速值校验失败");
-				return;
-			}
-		} catch (Exception ex) {
-			ScheduleSpeedRetry("恢复原始基础移速失败", ex);
-			return;
-		}
-		ClearSpeedOverrideState();
+		_ = force; // A multiplier hook has no stale memory value to force-write.
+		SetSpeedMultiplier(1f);
 	}
 
-	private static void ClearSpeedOverrideState() {
-		_speedOverridden = false;
-		_overriddenSpeedAddress = IntPtr.Zero;
-		_originalSpeed = 0f;
-		_restoreWalkingBaseSpeed = 0f;
-		_restoreMountedBaseSpeed = 0f;
-		_overrideMounted = false;
-		_lSpeed = float.NaN;
-		ClearSpeedRetry();
+	private static void SetSpeedMultiplier(float multiplier, float maxMultiplier = 0f) {
+		if (!IsValidSpeedValue(multiplier)) multiplier = 1f;
+		if (!IsValidSpeedValue(maxMultiplier)) {
+			if (multiplier > 1f) multiplier = 1f;
+			maxMultiplier = 0f;
+		}
+		var previous = Volatile.Read(ref _speedMultiplierState);
+		if (SpeedApproximatelyEquals(previous.Multiplier, multiplier) &&
+		    SpeedApproximatelyEquals(previous.MaxMultiplier, maxMultiplier)) return;
+		Volatile.Write(ref _speedMultiplierState, new SpeedMultiplierState(multiplier, maxMultiplier));
+		if (!Configuration.SpeedDebugOutput || _speedMultiplierCalculateHook == null) return;
+		try {
+			ChatBox.SendMessage($"/e SpeedMultiplier: {previous.Multiplier}->{multiplier}, max={maxMultiplier}");
+		} catch (Exception ex) {
+			Log.Error(ex, "[SpeedMultiplier] 输出调试信息失败");
+		}
+	}
+
+	//hook游戏内基础移速
+	private static float SpeedMultiplierCalculateDetour(nint characterSpeedContainer) {
+		var originalMultiplier = _speedMultiplierCalculateOriginal!(characterSpeedContainer);
+		var state = Volatile.Read(ref _speedMultiplierState);
+		return CalculateFinalSpeedMultiplier(originalMultiplier, state.Multiplier, state.MaxMultiplier);
+	}
+
+	private static float CalculateFinalSpeedMultiplier(float originalMultiplier, float multiplier, float maxMultiplier) {
+		if (!float.IsFinite(originalMultiplier) || originalMultiplier < 0f) return 0f;
+		if (originalMultiplier == 0f) return 0f;
+		if (!IsValidSpeedValue(multiplier)) multiplier = 1f;
+		if (multiplier <= 1f) return originalMultiplier * multiplier;
+		if (!IsValidSpeedValue(maxMultiplier)) return originalMultiplier;
+		var result = (double)originalMultiplier * multiplier;
+		return (float)Math.Min(result, maxMultiplier);
+	}
+
+	private static void InitializeSpeedMultiplierHook() {
+		if (_speedMultiplierCalculateHook != null) return;
+		if (Environment.TickCount64 < _speedHookRetryAfter) return;
+		_speedHookRetryAfter = Environment.TickCount64 + SpeedHookRetryDelayMilliseconds;
+		Hook<SpeedMultiplierCalculateDelegate>? hook = null;
+		try {
+			if (!SigScanner.TryScanText(SpeedMultiplierCalculateSignature, out var address) || address == IntPtr.Zero) {
+				LogSpeedHookFailure("未找到移速倍率计算签名");
+				return;
+			}
+			hook = GameInteropProvider.HookFromAddress(address, (SpeedMultiplierCalculateDelegate)SpeedMultiplierCalculateDetour);
+			_speedMultiplierCalculateOriginal = hook.OriginalDisposeSafe;
+			_speedMultiplierCalculateHook = hook;
+			hook.Enable();
+			_speedHookRetryAfter = 0;
+			_speedHookFailureLogged = false;
+		} catch (Exception ex) {
+			try {
+				hook?.Dispose();
+			} catch (Exception disposeException) {
+				Log.Error(disposeException, "[SpeedMultiplier] 清理初始化失败的 Hook 时出错");
+			}
+			_speedMultiplierCalculateHook = null;
+			LogSpeedHookFailure("建立移速倍率 Hook 失败", ex);
+		}
+	}
+
+	private static void DisposeSpeedMultiplierHook() {
+		Volatile.Write(ref _speedMultiplierState, new SpeedMultiplierState(1f, 0f));
+		_speedHookRetryAfter = 0;
+		var hook = _speedMultiplierCalculateHook;
+		if (hook == null) return;
+		try {
+			hook.Dispose();
+		} catch (Exception ex) {
+			Log.Error(ex, "[SpeedMultiplier] 释放移速倍率 Hook 失败");
+		} finally {
+			_speedMultiplierCalculateHook = null;
+		}
 	}
 
 	private static bool SpeedApproximatelyEquals(float left, float right) => Math.Abs(left - right) <= SpeedComparisonTolerance;
 
-	private static bool SpeedRetryPending() => Environment.TickCount64 < _speedRetryAfter;
-
-	private static void ScheduleSpeedRetry(string message, Exception? exception = null) {
-		_speedRetryAfter = Environment.TickCount64 + SpeedRetryDelayMilliseconds;
-		LogSpeedFailure(message, exception);
-	}
-
-	private static void ClearSpeedRetry() {
-		_speedRetryAfter = 0;
-		_speedFailureLogged = false;
-	}
-
-	private static bool TryResolveBaseMovementSpeedAddress(out IntPtr address) {
-		if (BaseMovementSpeedPtr.HasValue) {
-			address = BaseMovementSpeedPtr.Value;
-			return true;
-		}
-		address = IntPtr.Zero;
-		if (_speedScanAttempted) return false;
-		_speedScanAttempted = true;
-		try {
-			if (!SigScanner.TryScanText(BaseMovementSpeedSignature, out var signature) || signature == IntPtr.Zero) {
-				_speedScanAttempted = false;
-				ScheduleSpeedRetry("未找到基础移速签名");
-				return false;
-			}
-			var displacementAddress = signature + 3;
-			address = displacementAddress + Marshal.ReadInt32(displacementAddress) + 4 + BaseMovementSpeedOffset;
-			if (address == IntPtr.Zero) {
-				_speedScanAttempted = false;
-				ScheduleSpeedRetry("基础移速地址无效");
-				return false;
-			}
-			BaseMovementSpeedPtr = address;
-			return true;
-		} catch (Exception ex) {
-			_speedScanAttempted = false;
-			ScheduleSpeedRetry("解析基础移速地址失败", ex);
-			address = IntPtr.Zero;
-			return false;
-		}
-	}
-
-	private static void LogSpeedFailure(string message, Exception? exception = null) {
-		if (_speedFailureLogged) return;
-		_speedFailureLogged = true;
-		if (exception == null) Log.Error($"[BaseMovementSpeed] {message}");
-		else Log.Error(exception, $"[BaseMovementSpeed] {message}");
+	private static void LogSpeedHookFailure(string message, Exception? exception = null) {
+		if (_speedHookFailureLogged) return;
+		_speedHookFailureLogged = true;
+		if (exception == null) Log.Error($"[SpeedMultiplier] {message}");
+		else Log.Error(exception, $"[SpeedMultiplier] {message}");
 	}
 
 	[GeneratedRegex("^财宝好像是在(?<direction>正北|东北|正东|东南|正南|西南|正西|西北)方向(?<distance>(很远|稍远|不远|很近))的地方！")]

--- a/SkyEye/Plugin.cs
+++ b/SkyEye/Plugin.cs
@@ -40,8 +40,11 @@ namespace SkyEye;
 public sealed partial class Plugin : IDalamudPlugin {
 	private const uint LuckyCarrotItemId = 2002482;
 	private const uint LuckyPotItemId = 2003296;
+	private const int CurrentConfigurationVersion = 1;
+	private const string BaseMovementSpeedSignature = "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 84 C0 75 4F";
+	private const int BaseMovementSpeedOffset = 0x58;
 	internal const int FarmTimeout = 50;
-	private static float _lSpeed = 1f;
+	private static float _lSpeed = float.NaN;
 	internal static List<Vector3> DetectedTreasurePositions = [];
 	internal static readonly List<IPlayerCharacter> OtherPlayer = [];
 	internal static readonly List<Vector3> ElementalPositions = [];
@@ -53,7 +56,10 @@ public sealed partial class Plugin : IDalamudPlugin {
 	private static readonly Lock KillingLock = new();
 	internal static Vector3? lastFarmPos;
 	internal static bool FarmFull;
-	private static IntPtr? SpeedPtr;
+	private static IntPtr? BaseMovementSpeedPtr;
+	private static IntPtr _overriddenSpeedAddress;
+	private static float _originalSpeed;
+	private static bool _speedOverridden, _speedScanAttempted, _speedFailureLogged, _speedApplyDisabled, _restoreFailed;
 	internal static SpeedInfo? CurrentSpeedInfo;
 	internal static Dictionary<string, string> MapInfo = new();
 	private static Timer _carrotTimer = null!, _potTimer = null!;
@@ -85,6 +91,7 @@ public sealed partial class Plugin : IDalamudPlugin {
 			if (Configuration.AutoPot) UsePotCarrot();
 			else StopPotTimer();
 		};
+		mountState = Condition[ConditionFlag.Mounted];
 		Framework.Update += UpdateRoundPlayers;
 		Framework.Update += Farm;
 		Framework.Update += FindElemental;
@@ -95,24 +102,20 @@ public sealed partial class Plugin : IDalamudPlugin {
 		ChatGui.ChatMessageUnhandled += ChatPot;
 		ChatGui.ChatMessageUnhandled += ChatMoonPack;
 		ChatGui.ChatMessageUnhandled += Chat30OccultTreasure;
-		if (Configuration.SpeedUp.Count == 0) {
-			Configuration.SpeedUp.Add(SpeedInfo.Default());
-			Configuration.SpeedUp.Add(new SpeedInfo());
-		}
+		var configChanged = MigrateConfiguration();
+		configChanged |= EnsureDefaultSpeedInfo();
+		configChanged |= DisableAutoTreasureOnTerritoryEnter(ClientState.TerritoryType);
+		if (configChanged) Configuration.Save();
 		MapInfo = DataManager.GetExcelSheet<TerritoryType>().Where(i => !i.PlaceNameRegion.Value.Name.IsEmpty)
 			.ToDictionary(i => i.RowId.ToString(), i => $"{i.PlaceNameRegion.Value.Name}|{i.PlaceName.Value.Name}");
-		foreach (var s in Configuration.SpeedUp.Where(s => s.Enabled && s.SpeedUpTerritory.Split('|').Contains(ClientState.TerritoryType.ToString()))) {
-			CurrentSpeedInfo = s;
-			break;
-		}
+		RefreshCurrentSpeedInfo(ClientState.TerritoryType);
 		if (Configuration.NameReplacement) EnableNameplate();
-		SetSpeed(1);
 	}
 
 	private void CheckState(IFramework _) {
-		if (!InArea() || Condition[ConditionFlag.Mounted] == mountState) return;
+		if (Condition[ConditionFlag.Mounted] == mountState) return;
 		mountState = Condition[ConditionFlag.Mounted];
-		SetSpeed(1);
+		RestoreSpeed(true);
 	}
 
 	private void OnCommand() => OnCommand(null, null);
@@ -149,7 +152,7 @@ public sealed partial class Plugin : IDalamudPlugin {
 		Framework.Update -= FindElemental;
 		Framework.Update -= CheckState;
 		DisableNameplate();
-		SetSpeed(1);
+		RestoreSpeed(true);
 		_uiBuilder.Dispose();
 		CommandManager.RemoveHandler("/skyeye");
 		_carrotTimer.Stop();
@@ -209,6 +212,7 @@ public sealed partial class Plugin : IDalamudPlugin {
 	}
 
 	internal static void FindPot(bool force = false) {
+		if (!Configuration.EnableOccultPotNavigation) return;
 		if (!force && (_potTimer is { Enabled: true } || Condition[ConditionFlag.InCombat] || wait4chest)) return;
 		if (!string.IsNullOrEmpty(Configuration.BeforeGotoNewPot))
 			foreach (var cmd in Configuration.BeforeGotoNewPot.Split('|'))
@@ -372,7 +376,7 @@ public sealed partial class Plugin : IDalamudPlugin {
 	internal static bool InEureka() => ObjectTable.LocalPlayer != null && InEureka(ClientState.TerritoryType);
 	internal static bool InOccult() => ObjectTable.LocalPlayer != null && InOccult(ClientState.TerritoryType);
 	internal static bool InEureka(uint id) => (Territory)id is Territory.Anemos or Territory.Pagos or Territory.Pyros or Territory.Hydatos;
-	private static bool InOccult(uint id) => id == 1252;
+	internal static bool InOccult(uint id) => id == 1252;
 
 	internal static bool InArea() => InEureka() || CurrentSpeedInfo != null;
 	internal static Vector3 Pos2Map(Vector2 pos) => ToVector3(MapToWorld(pos, 200, 11f, (Territory)ClientState.TerritoryType == Territory.Hydatos ? 20.25f : 11.25f));
@@ -593,35 +597,236 @@ public sealed partial class Plugin : IDalamudPlugin {
 	}
 
 	internal static bool GreenNearby() {
+		var localPlayer = ObjectTable.LocalPlayer;
+		if (localPlayer == null) return false;
 		var friends = Configuration.SpeedUpFriendly.Split('|');
-		return OtherPlayer.Any(i => !friends.Contains(i.Name.ToString()) && Vector3.Distance(i.Position, ObjectTable.LocalPlayer!.Position) < (110 ^ 2));
+		return OtherPlayer.Any(i => !friends.Contains(i.Name.ToString()) && Vector3.DistanceSquared(i.Position, localPlayer.Position) < 110f * 110f);
 	}
 
 	private static void UpdateRoundPlayers(IFramework _) {
-		if (!Configuration.PluginEnabled || ObjectTable.LocalPlayer == null || !InArea() || CurrentSpeedInfo == null) return;
+		if (!Configuration.PluginEnabled || !Configuration.SpeedUpEnabled || ObjectTable.LocalPlayer == null || !InArea() || CurrentSpeedInfo == null) {
+			RestoreSpeed();
+			return;
+		}
 		OtherPlayer.Clear();
 		foreach (var obj in ObjectTable)
 			if (obj.GameObjectId != ObjectTable.LocalPlayer.GameObjectId & obj.Address.ToInt64() != 0 && obj is IPlayerCharacter rcTemp)
 				OtherPlayer.Add(rcTemp);
-		SetSpeed(!Configuration.SpeedUpEnabled || GreenNearby() ? 1f : CurrentSpeedInfo.SpeedUpN);
+		if (GreenNearby()) RestoreSpeed();
+		else ApplyBaseMovementSpeedOverride();
+	}
+
+	internal static SpeedInfo? FindSpeedInfo(uint territoryType) {
+		var territory = territoryType.ToString();
+		return Configuration.SpeedUp.FirstOrDefault(s =>
+			s != null &&
+			s.Enabled &&
+			!string.IsNullOrWhiteSpace(s.SpeedUpTerritory ?? string.Empty) &&
+			(s.SpeedUpTerritory ?? string.Empty).Split('|').Contains(territory) &&
+			IsValidSpeedValue(s.BaseMovementSpeed) &&
+			IsValidSpeedValue(s.MountBaseMovementSpeed) &&
+			IsValidSpeedValue(s.SpeedUpN) &&
+			IsValidSpeedValue(s.SpeedUpMax));
+	}
+
+	internal static bool IsValidSpeedValue(float value) => float.IsFinite(value) && value > 0f;
+
+	internal static bool DisableAutoTreasureOnTerritoryEnter(uint territoryId) {
+		var changed = false;
+		if (Configuration.DisableAutoRabbitWhenTerritoryChanged && InEureka(territoryId)) {
+			changed |= Configuration.AutoRabbit;
+			changed |= Configuration.AutoForwardNewRabbit;
+			Configuration.AutoRabbit = false;
+			Configuration.AutoForwardNewRabbit = false;
+		}
+		if (Configuration.DisableAutoPotWhenTerritoryChanged && InOccult(territoryId)) {
+			changed |= Configuration.AutoPot;
+			changed |= Configuration.EnableOccultPotNavigation;
+			Configuration.AutoPot = false;
+			Configuration.EnableOccultPotNavigation = false;
+		}
+		return changed;
+	}
+
+	private static bool MigrateConfiguration() {
+		if (Configuration.Version >= CurrentConfigurationVersion) return false;
+		if (Configuration.Version < 1) {
+			Configuration.DisableAutoRabbitWhenTerritoryChanged = true;
+			Configuration.DisableAutoPotWhenTerritoryChanged = true;
+		}
+		Configuration.Version = CurrentConfigurationVersion;
+		return true;
+	}
+
+	private static bool EnsureDefaultSpeedInfo() {
+		var changed = false;
+		Configuration.SpeedUp ??= [];
+		if (Configuration.SpeedUp.Count == 0) {
+			Configuration.SpeedUp.Add(SpeedInfo.Default());
+			return true;
+		}
+		if (Configuration.SpeedUp.Any(speedInfo => speedInfo?.IsDefault == true)) return changed;
+		var legacyDefault = Configuration.SpeedUp.FirstOrDefault(speedInfo =>
+			speedInfo != null && SpeedInfo.HasLegacyDefaultCharacteristics(speedInfo));
+		if (legacyDefault != null) {
+			legacyDefault.IsDefault = true;
+			changed = true;
+		}
+		return changed;
+	}
+
+	internal static void RefreshCurrentSpeedInfo(uint? territoryType = null, bool resetFailures = false) {
+		if (resetFailures) ResetSpeedFailureState();
+		RestoreSpeed(true);
+		CurrentSpeedInfo = FindSpeedInfo(territoryType ?? ClientState.TerritoryType);
+	}
+
+	internal static void ResetSpeedFailureState() {
+		_speedApplyDisabled = false;
+		_speedScanAttempted = false;
+		_speedFailureLogged = false;
+		if (!_speedOverridden) _restoreFailed = false;
 	}
 
 	// https://github.com/Jaksuhn/ffxiv-bundleoftweaks
 	// https://github.com/MnFeN/Triggernometry
 	[SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
-	internal static void SetSpeed(float speedBase) {
-		if (CurrentSpeedInfo == null || !Configuration.SpeedUpEnabled) return;
+	internal static void ApplyBaseMovementSpeedOverride() {
+		var speedInfo = CurrentSpeedInfo;
+		if (_speedApplyDisabled || _restoreFailed || speedInfo == null || !Configuration.PluginEnabled || !Configuration.SpeedUpEnabled ||
+		    !IsValidSpeedValue(speedInfo.BaseMovementSpeed) || !IsValidSpeedValue(speedInfo.MountBaseMovementSpeed) ||
+		    !IsValidSpeedValue(speedInfo.SpeedUpN) || !IsValidSpeedValue(speedInfo.SpeedUpMax)) return;
 		var mounted = Condition[ConditionFlag.Mounted];
-		if (mounted) speedBase *= CurrentSpeedInfo.SpeedUpMountX;
-		if (_lSpeed == speedBase) return;
-		_lSpeed = speedBase;
-		if (SpeedPtr == null) {
-			var ba = SigScanner.ScanText("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 84 C0 75 4F") + 3;
-			SpeedPtr = ba + Marshal.ReadInt32(ba) + 4 + 0x58;
+		var baseSpeed = mounted ? speedInfo.MountBaseMovementSpeed : speedInfo.BaseMovementSpeed;
+		if (_speedOverridden) {
+			var requestedSpeed = Math.Min(speedInfo.SpeedUpMax, baseSpeed * speedInfo.SpeedUpN);
+			if (_lSpeed == requestedSpeed) return;
 		}
-		var finalspeed = Math.Min(CurrentSpeedInfo.SpeedUpMax, speedBase * 6);
-		ChatBox.SendMessage($"/e SetSpeed({(mounted ? 6 * CurrentSpeedInfo.SpeedUpMountX : 6)}x): {SafeMemory.Read<float>(SpeedPtr.Value, 1)![0]}->{finalspeed}");
-		SafeMemory.Write(SpeedPtr.Value, finalspeed);
+		if (!TryResolveBaseMovementSpeedAddress(out var address)) return;
+
+		float previousSpeed, finalSpeed;
+		try {
+			var values = SafeMemory.Read<float>(address, 1);
+			if (values == null || values.Length == 0 || !IsValidSpeedValue(values[0])) {
+				LogSpeedFailure("读取当前基础移速失败");
+				_speedApplyDisabled = true;
+				if (!_speedOverridden) BaseMovementSpeedPtr = null;
+				return;
+			}
+			previousSpeed = values[0];
+			finalSpeed = Math.Min(speedInfo.SpeedUpMax, baseSpeed * speedInfo.SpeedUpN);
+			if (!IsValidSpeedValue(finalSpeed)) {
+				LogSpeedFailure("计算得到的基础移速覆盖值无效");
+				_speedApplyDisabled = true;
+				return;
+			}
+			SafeMemory.Write(address, finalSpeed);
+		} catch (Exception ex) {
+			LogSpeedFailure("读写基础移速内存失败", ex);
+			_speedApplyDisabled = true;
+			if (!_speedOverridden) BaseMovementSpeedPtr = null;
+			return;
+		}
+
+		if (!_speedOverridden) {
+			_originalSpeed = previousSpeed;
+			_overriddenSpeedAddress = address;
+			_speedOverridden = true;
+		}
+		_lSpeed = finalSpeed;
+		if (Configuration.SpeedDebugOutput) {
+			try {
+				ChatBox.SendMessage($"/e SetBaseSpeed: mounted={mounted} base={baseSpeed}*rate={speedInfo.SpeedUpN} capped={speedInfo.SpeedUpMax} {previousSpeed}->{finalSpeed}");
+			} catch (Exception ex) {
+				LogSpeedFailure("基础移速调试输出失败", ex);
+			}
+		}
+	}
+
+	internal static void RestoreSpeed(bool force = false) {
+		if (!_speedOverridden) {
+			_lSpeed = float.NaN;
+			return;
+		}
+		if (_restoreFailed && !force) return;
+		var addressValue = _overriddenSpeedAddress.ToInt64();
+		if (_overriddenSpeedAddress == IntPtr.Zero || addressValue < 0x10000 || addressValue > 0x00007FFFFFFFFFFF) {
+			LogSpeedFailure("缓存的基础移速地址不合理，取消恢复写入");
+			_restoreFailed = true;
+			return;
+		}
+		try {
+			var currentValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
+			if (currentValues == null || currentValues.Length == 0 || !float.IsFinite(currentValues[0])) {
+				LogSpeedFailure("恢复前无法确认基础移速地址可读，取消恢复写入");
+				_restoreFailed = true;
+				return;
+			}
+			if (Math.Abs(currentValues[0] - _originalSpeed) <= 0.0001f) {
+				ClearSpeedOverrideState();
+				return;
+			}
+			if (!float.IsFinite(_lSpeed) || Math.Abs(currentValues[0] - _lSpeed) > 0.0001f) {
+				LogSpeedFailure("恢复前当前基础移速与插件最后写入值不符，无法确认目标地址");
+				_restoreFailed = true;
+				return;
+			}
+			SafeMemory.Write(_overriddenSpeedAddress, _originalSpeed);
+			var restoredValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
+			if (restoredValues == null || restoredValues.Length == 0 || !float.IsFinite(restoredValues[0]) || Math.Abs(restoredValues[0] - _originalSpeed) > 0.0001f) {
+				LogSpeedFailure("恢复后基础移速值校验失败");
+				_restoreFailed = true;
+				return;
+			}
+		} catch (Exception ex) {
+			LogSpeedFailure("恢复原始基础移速失败", ex);
+			_restoreFailed = true;
+			return;
+		}
+		ClearSpeedOverrideState();
+	}
+
+	private static void ClearSpeedOverrideState() {
+		_speedOverridden = false;
+		_restoreFailed = false;
+		_overriddenSpeedAddress = IntPtr.Zero;
+		_originalSpeed = 0f;
+		_lSpeed = float.NaN;
+	}
+
+	private static bool TryResolveBaseMovementSpeedAddress(out IntPtr address) {
+		if (BaseMovementSpeedPtr.HasValue) {
+			address = BaseMovementSpeedPtr.Value;
+			return true;
+		}
+		address = IntPtr.Zero;
+		if (_speedScanAttempted) return false;
+		_speedScanAttempted = true;
+		try {
+			if (!SigScanner.TryScanText(BaseMovementSpeedSignature, out var signature) || signature == IntPtr.Zero) {
+				LogSpeedFailure("未找到基础移速签名");
+				return false;
+			}
+			var displacementAddress = signature + 3;
+			address = displacementAddress + Marshal.ReadInt32(displacementAddress) + 4 + BaseMovementSpeedOffset;
+			if (address == IntPtr.Zero) {
+				LogSpeedFailure("基础移速地址无效");
+				return false;
+			}
+			BaseMovementSpeedPtr = address;
+			return true;
+		} catch (Exception ex) {
+			LogSpeedFailure("解析基础移速地址失败", ex);
+			address = IntPtr.Zero;
+			return false;
+		}
+	}
+
+	private static void LogSpeedFailure(string message, Exception? exception = null) {
+		if (_speedFailureLogged) return;
+		_speedFailureLogged = true;
+		if (exception == null) Log.Error($"[BaseMovementSpeed] {message}");
+		else Log.Error(exception, $"[BaseMovementSpeed] {message}");
 	}
 
 	[GeneratedRegex("^财宝好像是在(?<direction>正北|东北|正东|东南|正南|西南|正西|西北)方向(?<distance>(很远|稍远|不远|很近))的地方！")]

--- a/SkyEye/Plugin.cs
+++ b/SkyEye/Plugin.cs
@@ -43,6 +43,8 @@ public sealed partial class Plugin : IDalamudPlugin {
 	private const int CurrentConfigurationVersion = 1;
 	private const string BaseMovementSpeedSignature = "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 84 C0 75 4F";
 	private const int BaseMovementSpeedOffset = 0x58;
+	private const float SpeedComparisonTolerance = 0.001f;
+	private const long SpeedRetryDelayMilliseconds = 1000;
 	internal const int FarmTimeout = 50;
 	private static float _lSpeed = float.NaN;
 	internal static List<Vector3> DetectedTreasurePositions = [];
@@ -58,8 +60,9 @@ public sealed partial class Plugin : IDalamudPlugin {
 	internal static bool FarmFull;
 	private static IntPtr? BaseMovementSpeedPtr;
 	private static IntPtr _overriddenSpeedAddress;
-	private static float _originalSpeed;
-	private static bool _speedOverridden, _speedScanAttempted, _speedFailureLogged, _speedApplyDisabled, _restoreFailed;
+	private static float _originalSpeed, _restoreWalkingBaseSpeed, _restoreMountedBaseSpeed;
+	private static long _speedRetryAfter;
+	private static bool _speedOverridden, _speedScanAttempted, _speedFailureLogged, _overrideMounted;
 	internal static SpeedInfo? CurrentSpeedInfo;
 	internal static Dictionary<string, string> MapInfo = new();
 	private static Timer _carrotTimer = null!, _potTimer = null!;
@@ -92,10 +95,10 @@ public sealed partial class Plugin : IDalamudPlugin {
 			else StopPotTimer();
 		};
 		mountState = Condition[ConditionFlag.Mounted];
+		Framework.Update += CheckState;
 		Framework.Update += UpdateRoundPlayers;
 		Framework.Update += Farm;
 		Framework.Update += FindElemental;
-		Framework.Update += CheckState;
 		PluginInterface.UiBuilder.OpenConfigUi += OnCommand;
 		PluginInterface.UiBuilder.Draw += WindowSystem.Draw;
 		ChatGui.ChatMessageUnhandled += ChatRabbit;
@@ -604,7 +607,8 @@ public sealed partial class Plugin : IDalamudPlugin {
 	}
 
 	private static void UpdateRoundPlayers(IFramework _) {
-		if (!Configuration.PluginEnabled || !Configuration.SpeedUpEnabled || ObjectTable.LocalPlayer == null || !InArea() || CurrentSpeedInfo == null) {
+		if (!Configuration.PluginEnabled || !Configuration.SpeedUpEnabled || ObjectTable.LocalPlayer == null ||
+		    Condition[ConditionFlag.BetweenAreas] || Condition[ConditionFlag.BetweenAreas51] || !InArea() || CurrentSpeedInfo == null) {
 			RestoreSpeed();
 			return;
 		}
@@ -682,10 +686,9 @@ public sealed partial class Plugin : IDalamudPlugin {
 	}
 
 	internal static void ResetSpeedFailureState() {
-		_speedApplyDisabled = false;
+		_speedRetryAfter = 0;
 		_speedScanAttempted = false;
 		_speedFailureLogged = false;
-		if (!_speedOverridden) _restoreFailed = false;
 	}
 
 	// https://github.com/Jaksuhn/ffxiv-bundleoftweaks
@@ -693,14 +696,29 @@ public sealed partial class Plugin : IDalamudPlugin {
 	[SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
 	internal static void ApplyBaseMovementSpeedOverride() {
 		var speedInfo = CurrentSpeedInfo;
-		if (_speedApplyDisabled || _restoreFailed || speedInfo == null || !Configuration.PluginEnabled || !Configuration.SpeedUpEnabled ||
+		if (SpeedRetryPending() || speedInfo == null || !Configuration.PluginEnabled || !Configuration.SpeedUpEnabled ||
 		    !IsValidSpeedValue(speedInfo.BaseMovementSpeed) || !IsValidSpeedValue(speedInfo.MountBaseMovementSpeed) ||
 		    !IsValidSpeedValue(speedInfo.SpeedUpN) || !IsValidSpeedValue(speedInfo.SpeedUpMax)) return;
 		var mounted = Condition[ConditionFlag.Mounted];
 		var baseSpeed = mounted ? speedInfo.MountBaseMovementSpeed : speedInfo.BaseMovementSpeed;
+		var requestedSpeed = Math.Min(speedInfo.SpeedUpMax, baseSpeed * speedInfo.SpeedUpN);
 		if (_speedOverridden) {
-			var requestedSpeed = Math.Min(speedInfo.SpeedUpMax, baseSpeed * speedInfo.SpeedUpN);
-			if (_lSpeed == requestedSpeed) return;
+			try {
+				var activeValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
+				if (activeValues == null || activeValues.Length == 0 || !IsValidSpeedValue(activeValues[0])) {
+					ScheduleSpeedRetry("无法校验当前基础移速覆盖值");
+					return;
+				}
+				if (float.IsFinite(_lSpeed) && SpeedApproximatelyEquals(activeValues[0], _lSpeed)) {
+					if (SpeedApproximatelyEquals(_lSpeed, requestedSpeed)) return;
+				} else {
+					Log.Information($"[BaseMovementSpeed] 检测到游戏重置基础移速为 {activeValues[0]}，重新建立覆盖状态");
+					ClearSpeedOverrideState();
+				}
+			} catch (Exception ex) {
+				ScheduleSpeedRetry("校验当前基础移速覆盖值失败", ex);
+				return;
+			}
 		}
 		if (!TryResolveBaseMovementSpeedAddress(out var address)) return;
 
@@ -708,32 +726,39 @@ public sealed partial class Plugin : IDalamudPlugin {
 		try {
 			var values = SafeMemory.Read<float>(address, 1);
 			if (values == null || values.Length == 0 || !IsValidSpeedValue(values[0])) {
-				LogSpeedFailure("读取当前基础移速失败");
-				_speedApplyDisabled = true;
-				if (!_speedOverridden) BaseMovementSpeedPtr = null;
+				ScheduleSpeedRetry("读取当前基础移速失败");
+				if (!_speedOverridden) {
+					BaseMovementSpeedPtr = null;
+					_speedScanAttempted = false;
+				}
 				return;
 			}
 			previousSpeed = values[0];
-			finalSpeed = Math.Min(speedInfo.SpeedUpMax, baseSpeed * speedInfo.SpeedUpN);
+			finalSpeed = requestedSpeed;
 			if (!IsValidSpeedValue(finalSpeed)) {
-				LogSpeedFailure("计算得到的基础移速覆盖值无效");
-				_speedApplyDisabled = true;
+				ScheduleSpeedRetry("计算得到的基础移速覆盖值无效");
 				return;
 			}
 			SafeMemory.Write(address, finalSpeed);
 		} catch (Exception ex) {
-			LogSpeedFailure("读写基础移速内存失败", ex);
-			_speedApplyDisabled = true;
-			if (!_speedOverridden) BaseMovementSpeedPtr = null;
+			ScheduleSpeedRetry("读写基础移速内存失败", ex);
+			if (!_speedOverridden) {
+				BaseMovementSpeedPtr = null;
+				_speedScanAttempted = false;
+			}
 			return;
 		}
 
 		if (!_speedOverridden) {
 			_originalSpeed = previousSpeed;
+			_restoreWalkingBaseSpeed = speedInfo.BaseMovementSpeed;
+			_restoreMountedBaseSpeed = speedInfo.MountBaseMovementSpeed;
+			_overrideMounted = mounted;
 			_overriddenSpeedAddress = address;
 			_speedOverridden = true;
 		}
 		_lSpeed = finalSpeed;
+		ClearSpeedRetry();
 		if (Configuration.SpeedDebugOutput) {
 			try {
 				ChatBox.SendMessage($"/e SetBaseSpeed: mounted={mounted} base={baseSpeed}*rate={speedInfo.SpeedUpN} capped={speedInfo.SpeedUpMax} {previousSpeed}->{finalSpeed}");
@@ -748,39 +773,43 @@ public sealed partial class Plugin : IDalamudPlugin {
 			_lSpeed = float.NaN;
 			return;
 		}
-		if (_restoreFailed && !force) return;
+		if (!force && SpeedRetryPending()) return;
 		var addressValue = _overriddenSpeedAddress.ToInt64();
 		if (_overriddenSpeedAddress == IntPtr.Zero || addressValue < 0x10000 || addressValue > 0x00007FFFFFFFFFFF) {
-			LogSpeedFailure("缓存的基础移速地址不合理，取消恢复写入");
-			_restoreFailed = true;
+			ScheduleSpeedRetry("缓存的基础移速地址不合理，暂缓恢复写入");
 			return;
 		}
 		try {
 			var currentValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
 			if (currentValues == null || currentValues.Length == 0 || !float.IsFinite(currentValues[0])) {
-				LogSpeedFailure("恢复前无法确认基础移速地址可读，取消恢复写入");
-				_restoreFailed = true;
+				ScheduleSpeedRetry("恢复前无法确认基础移速地址可读，暂缓恢复写入");
 				return;
 			}
-			if (Math.Abs(currentValues[0] - _originalSpeed) <= 0.0001f) {
+			var mounted = Condition[ConditionFlag.Mounted];
+			var restoreSpeed = mounted == _overrideMounted
+				? _originalSpeed
+				: mounted ? _restoreMountedBaseSpeed : _restoreWalkingBaseSpeed;
+			if (!IsValidSpeedValue(restoreSpeed)) {
+				ScheduleSpeedRetry("没有可用的基础移速恢复值");
+				return;
+			}
+			if (SpeedApproximatelyEquals(currentValues[0], restoreSpeed)) {
 				ClearSpeedOverrideState();
 				return;
 			}
-			if (!float.IsFinite(_lSpeed) || Math.Abs(currentValues[0] - _lSpeed) > 0.0001f) {
-				LogSpeedFailure("恢复前当前基础移速与插件最后写入值不符，无法确认目标地址");
-				_restoreFailed = true;
+			if (!float.IsFinite(_lSpeed) || !SpeedApproximatelyEquals(currentValues[0], _lSpeed)) {
+				Log.Warning($"[BaseMovementSpeed] 当前值已被游戏或其他插件改为 {currentValues[0]}，放弃旧覆盖状态，不写入过期恢复值");
+				ClearSpeedOverrideState();
 				return;
 			}
-			SafeMemory.Write(_overriddenSpeedAddress, _originalSpeed);
+			SafeMemory.Write(_overriddenSpeedAddress, restoreSpeed);
 			var restoredValues = SafeMemory.Read<float>(_overriddenSpeedAddress, 1);
-			if (restoredValues == null || restoredValues.Length == 0 || !float.IsFinite(restoredValues[0]) || Math.Abs(restoredValues[0] - _originalSpeed) > 0.0001f) {
-				LogSpeedFailure("恢复后基础移速值校验失败");
-				_restoreFailed = true;
+			if (restoredValues == null || restoredValues.Length == 0 || !float.IsFinite(restoredValues[0]) || !SpeedApproximatelyEquals(restoredValues[0], restoreSpeed)) {
+				ScheduleSpeedRetry("恢复后基础移速值校验失败");
 				return;
 			}
 		} catch (Exception ex) {
-			LogSpeedFailure("恢复原始基础移速失败", ex);
-			_restoreFailed = true;
+			ScheduleSpeedRetry("恢复原始基础移速失败", ex);
 			return;
 		}
 		ClearSpeedOverrideState();
@@ -788,10 +817,27 @@ public sealed partial class Plugin : IDalamudPlugin {
 
 	private static void ClearSpeedOverrideState() {
 		_speedOverridden = false;
-		_restoreFailed = false;
 		_overriddenSpeedAddress = IntPtr.Zero;
 		_originalSpeed = 0f;
+		_restoreWalkingBaseSpeed = 0f;
+		_restoreMountedBaseSpeed = 0f;
+		_overrideMounted = false;
 		_lSpeed = float.NaN;
+		ClearSpeedRetry();
+	}
+
+	private static bool SpeedApproximatelyEquals(float left, float right) => Math.Abs(left - right) <= SpeedComparisonTolerance;
+
+	private static bool SpeedRetryPending() => Environment.TickCount64 < _speedRetryAfter;
+
+	private static void ScheduleSpeedRetry(string message, Exception? exception = null) {
+		_speedRetryAfter = Environment.TickCount64 + SpeedRetryDelayMilliseconds;
+		LogSpeedFailure(message, exception);
+	}
+
+	private static void ClearSpeedRetry() {
+		_speedRetryAfter = 0;
+		_speedFailureLogged = false;
 	}
 
 	private static bool TryResolveBaseMovementSpeedAddress(out IntPtr address) {
@@ -804,19 +850,22 @@ public sealed partial class Plugin : IDalamudPlugin {
 		_speedScanAttempted = true;
 		try {
 			if (!SigScanner.TryScanText(BaseMovementSpeedSignature, out var signature) || signature == IntPtr.Zero) {
-				LogSpeedFailure("未找到基础移速签名");
+				_speedScanAttempted = false;
+				ScheduleSpeedRetry("未找到基础移速签名");
 				return false;
 			}
 			var displacementAddress = signature + 3;
 			address = displacementAddress + Marshal.ReadInt32(displacementAddress) + 4 + BaseMovementSpeedOffset;
 			if (address == IntPtr.Zero) {
-				LogSpeedFailure("基础移速地址无效");
+				_speedScanAttempted = false;
+				ScheduleSpeedRetry("基础移速地址无效");
 				return false;
 			}
 			BaseMovementSpeedPtr = address;
 			return true;
 		} catch (Exception ex) {
-			LogSpeedFailure("解析基础移速地址失败", ex);
+			_speedScanAttempted = false;
+			ScheduleSpeedRetry("解析基础移速地址失败", ex);
 			address = IntPtr.Zero;
 			return false;
 		}

--- a/SkyEye/UIBuilder.cs
+++ b/SkyEye/UIBuilder.cs
@@ -44,15 +44,7 @@ internal class UiBuilder : IDisposable {
 	}
 
 	private static void TerritoryChanged(uint u) {
-		if (Configuration.DisableAutoRabbitWhenTerritoryChanged) {
-			Configuration.AutoRabbit = false;
-			Configuration.AutoForwardNewRabbit = false;
-			Configuration.Save();
-		}
-		if (Configuration.DisableAutoPotWhenTerritoryChanged) {
-			Configuration.AutoPot = false;
-			Configuration.Save();
-		}
+		if (DisableAutoTreasureOnTerritoryEnter(u)) Configuration.Save();
 		if (InEureka(lastTerritoryId) || InEureka(ClientState.TerritoryType)) {
 			Plugin.ElementalPositions.Clear();
 			ElementalSet.Clear();
@@ -63,12 +55,7 @@ internal class UiBuilder : IDisposable {
 				DeadFateDic[p.Key][k] = "-1";
 		}
 		lastTerritoryId = ClientState.TerritoryType;
-		CurrentSpeedInfo = null;
-		foreach (var s in Configuration.SpeedUp.Where(s => s.Enabled && s.SpeedUpTerritory.Split('|').Contains(ClientState.TerritoryType.ToString()))) {
-			CurrentSpeedInfo = s;
-			break;
-		}
-		SetSpeed(1);
+		RefreshCurrentSpeedInfo(u, true);
 	}
 
 	private static uint LastPotId;

--- a/SkyEye/UIBuilder.cs
+++ b/SkyEye/UIBuilder.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Media;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.ClientState.Conditions;
@@ -402,25 +401,31 @@ internal class UiBuilder : IDisposable {
 		_mapOrigin = null;
 		if (!MapVisible) return;
 		var areaMapAddon = AreaMapAddon;
+		if (areaMapAddon == null) return;
 		_globalUiScale = areaMapAddon->Scale;
 		var areaMapAddonUldManager = areaMapAddon->UldManager;
 		if (areaMapAddonUldManager.NodeListCount <= 4) return;
 		var ptr = (AtkComponentNode*)areaMapAddonUldManager.NodeList[3];
+		if (ptr == null || ptr->Component == null) return;
 		var atkResNode = ptr->AtkResNode;
 		var ptrUldManager = ptr->Component->UldManager;
 		if (ptrUldManager.NodeListCount < 233) return;
 		var ptrUldManagerNodeList = ptrUldManager.NodeList;
 		for (var i = 6; i < ptrUldManager.NodeListCount - 1; i++) {
 			var item = ptrUldManagerNodeList[i];
-			if (!item->IsVisible()) continue;
+			if (item == null || !item->IsVisible()) continue;
 			var itemx = (AtkComponentNode*)item;
+			if (itemx->Component == null || itemx->Component->UldManager.NodeListCount <= 4) continue;
 			var ptr3 = (AtkImageNode*)itemx->Component->UldManager.NodeList[4];
+			if (ptr3 == null) continue;
 			var atkResNode2 = itemx->AtkResNode;
 			string? text = null;
 			var ptr3PartsList = ptr3->PartsList;
-			if (ptr3PartsList != null && ptr3->PartId <= ptr3PartsList->PartCount) {
-				var AtkTexture = (ptr3PartsList->Parts + ptr3->PartId * Unsafe.SizeOf<AtkUldPart>())->UldAsset->AtkTexture;
-				if (AtkTexture.TextureType == TextureType.Resource)
+			if (ptr3PartsList != null && ptr3PartsList->Parts != null && ptr3->PartId < ptr3PartsList->PartCount) {
+				var part = ptr3PartsList->Parts + ptr3->PartId;
+				if (part->UldAsset == null) continue;
+				var AtkTexture = part->UldAsset->AtkTexture;
+				if (AtkTexture.TextureType == TextureType.Resource && AtkTexture.Resource != null && AtkTexture.Resource->TexFileResourceHandle != null)
 					text = Path.GetFileName(AtkTexture.Resource->TexFileResourceHandle->ResourceHandle.FileName.ToString());
 			}
 			if (text is not ("060443.tex" or "060443_hr1.tex")) continue;

--- a/SkyEye/Util.cs
+++ b/SkyEye/Util.cs
@@ -44,8 +44,19 @@ internal static class Util {
 	}
 
 	internal static unsafe AddonAreaMap* AreaMapAddon => Plugin.Gui.GetAddonByName<AddonAreaMap>("AreaMap");
-	internal static unsafe bool MapVisible => AreaMapAddon->IsVisible;
-	internal static unsafe float MapScale => AreaMapAddon->AreaMap.MapScale;
+	internal static unsafe bool MapVisible {
+		get {
+			var addon = AreaMapAddon;
+			return addon != null && addon->IsVisible;
+		}
+	}
+
+	internal static unsafe float MapScale {
+		get {
+			var addon = AreaMapAddon;
+			return addon != null ? addon->AreaMap.MapScale : 1f;
+		}
+	}
 	internal static Vector2 ToVector2(Vector3 v) => new(v.X, v.Z);
 
 	internal static Vector3 ToVector3(Vector2 v) => new(v.X, 0f, v.Y);


### PR DESCRIPTION
## 主要改动

### 移速逻辑

- 将直接改写基础移速内存的实现替换为游戏移速倍率计算 Hook，按 Daily Routines 的方式使用 `Original × 配置倍率`
- 新增每行“最终倍率上限”，实际结果为 `min(游戏原始倍率 × 配置倍率, 最终倍率上限)`，技能增速叠加后也不会突破保护值
- 保留游戏原生减速、定身等倍率；仅在 SkyEye 主动加速时套用上限，附近有人、区域切换、关闭功能及卸载时恢复中性状态
- 倍率和上限通过不可变快照原子发布，避免 Detour 读取到不同步的配置值
- 非法倍率或上限按安全路径回退，并使用 `double` 中间值避免乘法溢出
- 配置版本升级到 2；旧配置按原有倍率迁移上限，保持普通移动速度不变

### 其他安全改动

- 修正附近玩家距离平方计算
- 月岛萝卜、罐子导航/传送改为显式开启，并支持进入区域时自动关闭相关自动化
- 自定义潜水 TP 指令保持可配置，并保留 LatihasDalamudCore 优先级
- 加固地图覆盖层的空指针与纹理资源访问

## 验证

- `C:\Users\Administrator\.dotnet\dotnet.exe build SkyEye.slnx --no-restore`
- 构建成功：0 个警告，0 个错误
- 移速倍率边界矩阵 14 项通过，包括技能增速触顶、减速、定身、非法值、恢复状态和溢出保护
- Dalamud 开发插件热重载成功，未出现 SkyEye/SpeedMultiplier Hook 异常

替代并废弃 #4。